### PR TITLE
Allow null passing

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,9 +32,13 @@
                     return;
                 }
 
-                keys.forEach(function (key) {
-                    size += (key + JSON.stringify(results[key])).length;
-                });
+                if (keys === null) {
+                    size += (JSON.stringify(results)).length;
+                } else {
+                    keys.forEach(function (key) {
+                        size += (key + JSON.stringify(results[key])).length;
+                    });
+                }
 
                 resolve(size);
             });


### PR DESCRIPTION
According to documentation[1], not only list of keys can be passed, but
also null to get total usage of all storage.

[1] https://developer.chrome.com/extensions/storage